### PR TITLE
[#28] feat : update timeslot status

### DIFF
--- a/src/main/java/com/popjub/reservationservice/application/port/StoreServicePort.java
+++ b/src/main/java/com/popjub/reservationservice/application/port/StoreServicePort.java
@@ -2,10 +2,13 @@ package com.popjub.reservationservice.application.port;
 
 import java.util.UUID;
 
+import com.popjub.reservationservice.application.port.dto.TimeSlotStatus;
 import com.popjub.reservationservice.application.port.dto.TimeslotResult;
 
 public interface StoreServicePort {
 	TimeslotResult getTimeslot(UUID timeslotId);
 
 	boolean validateCheckIn(UUID storeId, UUID timeslotId, Long userId);
+
+	void updateTimeslotStatus(UUID timeslotId, TimeSlotStatus status);
 }

--- a/src/main/java/com/popjub/reservationservice/application/service/ReservationService.java
+++ b/src/main/java/com/popjub/reservationservice/application/service/ReservationService.java
@@ -61,7 +61,7 @@ public class ReservationService {
 		}
 		Integer remaining;
 		try {
-			remaining = redisUtil.decreaseRemaining(command.timeslotId());
+			remaining = redisUtil.decreaseRemaining(command.timeslotId(), command.friendCnt() + 1);
 		} catch (ReservationCustomException e) {
 			throw e;
 		}
@@ -75,7 +75,7 @@ public class ReservationService {
 			timeslotResult.storeId(),
 			timeslotResult.reservationDate())) {
 
-			Integer restoreRemaining = redisUtil.increaseRemaining(command.timeslotId());
+			Integer restoreRemaining = redisUtil.increaseRemaining(command.timeslotId(), command.friendCnt() + 1);
 			if (remaining == 0 && restoreRemaining >= 1) {
 				storeServicePort.updateTimeslotStatus(command.timeslotId(), TimeSlotStatus.AVAILABLE);
 			}
@@ -112,9 +112,9 @@ public class ReservationService {
 		reservation.cancelReservation();
 		reservationRepository.save(reservation);
 
-		Integer remaining = redisUtil.increaseRemaining(reservation.getTimeslotId());
+		Integer remaining = redisUtil.increaseRemaining(reservation.getTimeslotId(), reservation.getFriendCnt() + 1);
 
-		if (remaining == 1) {
+		if (remaining >= 1) {
 			storeServicePort.updateTimeslotStatus(reservation.getTimeslotId(), TimeSlotStatus.AVAILABLE);
 		}
 		return CancelReservationResult.from(reservation);

--- a/src/main/java/com/popjub/reservationservice/application/service/ReservationService.java
+++ b/src/main/java/com/popjub/reservationservice/application/service/ReservationService.java
@@ -59,11 +59,15 @@ public class ReservationService {
 		if (status.isNotAvailable()) {
 			throw new ReservationCustomException(ReservationErrorCode.TIMESLOT_NOT_AVAILABLE);
 		}
-
+		Integer remaining;
 		try {
-			redisUtil.decreaseRemaining(command.timeslotId());
+			remaining = redisUtil.decreaseRemaining(command.timeslotId());
 		} catch (ReservationCustomException e) {
 			throw e;
+		}
+
+		if (remaining == 0) {
+			storeServicePort.updateTimeslotStatus(command.timeslotId(), TimeSlotStatus.FULL);
 		}
 
 		if (reservationRepository.existsByUserIdAndStoreIdAndReservationDate(
@@ -71,7 +75,10 @@ public class ReservationService {
 			timeslotResult.storeId(),
 			timeslotResult.reservationDate())) {
 
-			redisUtil.increaseRemaining(command.timeslotId());
+			Integer restoreRemaining = redisUtil.increaseRemaining(command.timeslotId());
+			if (remaining == 0 && restoreRemaining >= 1) {
+				storeServicePort.updateTimeslotStatus(command.timeslotId(), TimeSlotStatus.AVAILABLE);
+			}
 			throw new ReservationCustomException(ReservationErrorCode.DUPLICATE_RESERVATION);
 		}
 
@@ -105,7 +112,11 @@ public class ReservationService {
 		reservation.cancelReservation();
 		reservationRepository.save(reservation);
 
-		redisUtil.increaseRemaining(reservation.getTimeslotId());
+		Integer remaining = redisUtil.increaseRemaining(reservation.getTimeslotId());
+
+		if (remaining == 1) {
+			storeServicePort.updateTimeslotStatus(reservation.getTimeslotId(), TimeSlotStatus.AVAILABLE);
+		}
 		return CancelReservationResult.from(reservation);
 	}
 

--- a/src/main/java/com/popjub/reservationservice/exception/ReservationErrorCode.java
+++ b/src/main/java/com/popjub/reservationservice/exception/ReservationErrorCode.java
@@ -26,7 +26,8 @@ public enum ReservationErrorCode implements BaseErrorCode {
 	CHECKIN_NOT_AVAILABLE("체크인 가능한 상태가 아닙니다.", HttpStatus.BAD_REQUEST),
 	INVALID_CHECK_IN_DATE("체크인 가능한 날짜가 아닙니다.", HttpStatus.BAD_REQUEST),
 	CHECKIN_VALIDATION_FAILED("체크인 검증에 실패했습니다.", HttpStatus.BAD_REQUEST),
-	NO_SHOW_RESTRICTED("최근 6개월 내 노쇼 3회 이상으로 예약이 제한되었습니다.", HttpStatus.FORBIDDEN);
+	NO_SHOW_RESTRICTED("최근 6개월 내 노쇼 3회 이상으로 예약이 제한되었습니다.", HttpStatus.FORBIDDEN),
+	NO_AVAILABLE_SEAT("예약 가능한 잔여석이 없습니다.", HttpStatus.BAD_REQUEST);
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/popjub/reservationservice/infrastructure/client/MockStoreClient.java
+++ b/src/main/java/com/popjub/reservationservice/infrastructure/client/MockStoreClient.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Component;
 import com.popjub.reservationservice.application.port.dto.TimeSlotStatus;
 import com.popjub.reservationservice.infrastructure.client.dto.SearchTimeslotResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Component
 public class MockStoreClient {
 	/**
@@ -23,6 +26,13 @@ public class MockStoreClient {
 			LocalTime.of(12, 0, 0),
 			TimeSlotStatus.AVAILABLE,
 			60
+		);
+	}
+
+	public static void updateTimeslotStatus(UUID timeslotId, TimeSlotStatus status) {
+		log.info("업데이트 요청 : 타임슬롯 ID={}, 타임슬롯 상태={}",
+			timeslotId,
+			status
 		);
 	}
 }

--- a/src/main/java/com/popjub/reservationservice/infrastructure/client/StoreAdapter.java
+++ b/src/main/java/com/popjub/reservationservice/infrastructure/client/StoreAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.popjub.reservationservice.application.port.StoreServicePort;
+import com.popjub.reservationservice.application.port.dto.TimeSlotStatus;
 import com.popjub.reservationservice.application.port.dto.TimeslotResult;
 import com.popjub.reservationservice.infrastructure.client.dto.SearchTimeslotResponse;
 
@@ -72,5 +73,14 @@ public class StoreAdapter implements StoreServicePort {
 			return storeClient.validateCheckIn(storeId, timeslotId, userId);
 		}
 		return true;
+	}
+
+	@Override
+	public void updateTimeslotStatus(UUID timeslotId, TimeSlotStatus status) {
+
+		if (flag) {
+			storeClient.updateTimeslotStatus(timeslotId, status);
+		}
+		MockStoreClient.updateTimeslotStatus(timeslotId, status);
 	}
 }

--- a/src/main/java/com/popjub/reservationservice/infrastructure/client/StoreServiceClient.java
+++ b/src/main/java/com/popjub/reservationservice/infrastructure/client/StoreServiceClient.java
@@ -5,8 +5,10 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.popjub.reservationservice.application.port.dto.TimeSlotStatus;
 import com.popjub.reservationservice.infrastructure.client.dto.SearchTimeslotResponse;
 
 @FeignClient(name = "store-service", url = "localhost:18082/internal/stores")
@@ -22,4 +24,9 @@ public interface StoreServiceClient {
 		@RequestParam("userId") Long userId
 	);
 
+	@PostMapping("/timeslot/update-status")
+	void updateTimeslotStatus(
+		@RequestParam("timeslotId") UUID timeslotId,
+		@RequestParam("status") TimeSlotStatus status
+	);
 }

--- a/src/main/java/com/popjub/reservationservice/infrastructure/util/RedisUtil.java
+++ b/src/main/java/com/popjub/reservationservice/infrastructure/util/RedisUtil.java
@@ -46,9 +46,9 @@ public class RedisUtil {
 	/**
 	 * 예약 취소시 잔여석 증가 메소드
 	 */
-	public Integer increaseRemaining(UUID timeslotId) {
+	public Integer increaseRemaining(UUID timeslotId, Integer friendCnt) {
 		String key = generateKey(timeslotId);
-		Long remaining = redisTemplate.opsForValue().increment(key);
+		Long remaining = redisTemplate.opsForValue().increment(key, friendCnt);
 
 		return remaining.intValue();
 	}
@@ -56,14 +56,14 @@ public class RedisUtil {
 	/**
 	 * 예약 성공시 잔여석 감소 메소드
 	 */
-	public Integer decreaseRemaining(UUID timeslotId) {
+	public Integer decreaseRemaining(UUID timeslotId, Integer friendCnt) {
 		String key = generateKey(timeslotId);
 		if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
 			initializeCapacity(timeslotId);
 		}
-		Long remaining = redisTemplate.opsForValue().decrement(key);
+		Long remaining = redisTemplate.opsForValue().decrement(key, friendCnt);
 		if (remaining < 0) {
-			redisTemplate.opsForValue().increment(key);
+			redisTemplate.opsForValue().increment(key, friendCnt);
 			throw new ReservationCustomException(ReservationErrorCode.NO_AVAILABLE_SEAT);
 		}
 		return remaining.intValue();


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #28 

## 📝 작업 내용 상세 작성
- Redis 타임슬롯 잔여석 변경 시점 감지 로직 구현
- 잔여석 1 → 0 전환 시 스토어 서비스에 FULL 상태 변경 요청 전송
- 잔여석 0 → 1 전환 시 스토어 서비스에 AVAILABLE 상태 변경 요청 전송
- 예약 생성시 잔여석을 동반인원을 포함하지 않고 1만 차감하던 로직을 동반인원을 포함하도록 수정

## 🚀 PR 타입
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더 수정, 삭제

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.